### PR TITLE
trim

### DIFF
--- a/CFRNode_trim.java
+++ b/CFRNode_trim.java
@@ -9,14 +9,14 @@ public class CFRNode_trim {
 	private int num_valid_actions; //number of actions in this information set.
 	private final int iteration_mod = 3; //has to be at least 2 to allow updating only for the next iteration
 	private int current_iteration_mod_pointer = 0;
-	private double[][] utility_history;
 	public static final int UTILITY_HISTORY_LENGTH = 5000;
 	public static final double CUTOFF_THRESHOLD = 0.01;
 	public static final int NUM_PLAYERS = 2;
 	private double total_utility[];
 	private int utility_history_counter[];
 	private boolean[] trim;
-
+	private double[] mean_square_est; //sums the square of the averege utilities
+	private double[] mean_est; //sums the averege utilities
 	
 	public void Print() {
 	    System.out.println(Arrays.toString(getAverageStrategy()));
@@ -35,14 +35,17 @@ public class CFRNode_trim {
 		{
 			is_valid[a] = h.action_valid(a);
 		}
-		utility_history = new double[NUM_PLAYERS][UTILITY_HISTORY_LENGTH+1];
 		utility_history_counter = new int[NUM_PLAYERS];
 		trim = new boolean[NUM_PLAYERS];
 		total_utility = new double[NUM_PLAYERS];
+		mean_square_est = new double[NUM_PLAYERS];
+		mean_est = new double[NUM_PLAYERS];
 		for (int i=0; i< NUM_PLAYERS; i++){
 			utility_history_counter[i] = 0;
 			total_utility[i] = 0;
 			trim[i] = false;
+			mean_square_est[i] = 0;
+			mean_est[i] = 0;
 		}
 	}
 	public void updateTables(int player, int index, double regret, double pi0, double pi1, int current_iteration) {
@@ -61,14 +64,20 @@ public class CFRNode_trim {
 		strategySum[next_next_iteration_mod][index] = strategySum[next_iteration_mod][index];
 	}
 	public void updateUtility(double utility, int player){
-		total_utility[player] = total_utility[player] + utility;
 		utility_history_counter[player]++;
-		utility_history[player][utility_history_counter[player]] = total_utility[player] / utility_history_counter[player];
-		if (utility_history_counter[player] == UTILITY_HISTORY_LENGTH) {
+		total_utility[player] = total_utility[player] + utility;
+		double mean = get_mean(player);
+		mean_square_est[player] += mean*mean;
+		mean_est[player] += mean;
+		if (utility_history_counter[player] % UTILITY_HISTORY_LENGTH == 0) {
+			double var = get_var(player);
 			if (get_var(player) < CUTOFF_THRESHOLD) {
 				trim[player] = true;
 			}
-			utility_history_counter[player] = 0;	
+			else {
+				mean_square_est[player] = 0;
+				mean_est[player] = 0;
+			}
 		}
 	}
 	
@@ -77,17 +86,18 @@ public class CFRNode_trim {
 		else return false;
 	}
 	
-	public double get_mean(int player) {
-		return total_utility[player] / UTILITY_HISTORY_LENGTH;
+	public double get_mean(int player) { //returns avegare utility
+		return total_utility[player] / utility_history_counter[player];
+	}
+	
+	public double get_mean_est(int player) { //returns the average of the average utilities
+		return mean_est[player] / UTILITY_HISTORY_LENGTH;
 	}
 	
 	private double get_var(int player)  {
-		double mean = get_mean(player);
-		double var = 0.0;
-		for (int i=0; i<UTILITY_HISTORY_LENGTH; i++){
-			var += (utility_history[player][i]-mean)*(utility_history[player][i]-mean);
-		}
-		return var/UTILITY_HISTORY_LENGTH;
+		double mean_average = get_mean_est(player);
+		double var = mean_square_est[player]/ UTILITY_HISTORY_LENGTH - mean_average*mean_average;
+		return var;
 	}
 	
 	public double[] getStrategy(int current_iteration) 

--- a/TrainCFR_Vanilla_trim.java
+++ b/TrainCFR_Vanilla_trim.java
@@ -39,7 +39,8 @@ public class TrainCFR_Vanilla_trim {
 		
 		//if the utility is stable, return the mean utility
 		if (infoset_node.can_trim(player)) {
-			return infoset_node.get_mean(player);
+			//return infoset_node.get_mean(player);
+			return infoset_node.get_mean_est(player);
 		}
 		
 		//statistic to help compare different algorithms


### PR DESCRIPTION
Handles utility convergence book-keeping using 2 variables instead of UTILITY_HISTORY_LENGTH size array.
When trimming, returns the average of the last avegare utilities instead of the latest average utility, thus having average utility closer to vanilla. 
